### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # node-grpc-client
-Simple gRPC client on NodeJS v1.3.0
+Simple gRPC client on NodeJS v1.4.0
+
+### Important fix was solved in verison 1.4.0
+Now are supported packages which have *dots* or style of *inverse DNS* like: `com.github.nodegrpcclient`.
 
 ## Methods
 

--- a/index.js
+++ b/index.js
@@ -9,11 +9,23 @@ class GRPCClient {
             keepCase: (options.keepCase === undefined) ? true : options.keepCase,
             longs: (options.longs === undefined) ? String : options.longs,
             enums: (options.enums === undefined) ? String : options.enums,
-            defaults: (options.default === undefined) ? true: options.default,
-            oneofs:  (options.default === undefined) ? true : options.default
+            defaults: (options.default === undefined) ? true : options.default,
+            oneofs: (options.default === undefined) ? true : options.default
         });
 
-        const proto = grpc.loadPackageDefinition(this.packageDefinition)[packageName];
+        const proto = ((packageName) => {
+
+            const packagePath = packageName.split('.');
+            let proto = grpc.loadPackageDefinition(this.packageDefinition);
+
+            for (let $i = 0; $i <= packagePath.length - 1; $i++) {
+
+                proto = proto[packagePath[$i]];
+
+            }
+            return proto;
+        })(packageName);
+
 
         const listMethods = this.packageDefinition[`${packageName}.${service}`];
 
@@ -36,7 +48,7 @@ class GRPCClient {
             this[`${methodName}Stream`] = (data) => {
 
                 return this.client[methodName](data)
-                
+
             }
 
             this[`${methodName}Sync`] = (data) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-grpc-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-grpc-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Simple gRPC client on NodeJS",
   "main": "index.js",
   "author": "Santiago Yepes Tamayo<zetogk@gmail.com>",


### PR DESCRIPTION
In this MR was solved the issue related with package names. Only were supported names with a simple word or without inverse DNS style. Now it will be supported. Example of package name supported from now: `com.github.nodegrpcclient`,