### PR TITLE
dependencies(yarn.lock): Minimist 1.2.2 for security warning

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -295,7 +295,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@^1.2.2:
   version "1.2.0"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -456,7 +456,7 @@ rc@^1.2.7:
   dependencies:
     deep-extend "^0.6.0"
     ini "~1.3.0"
-    minimist "^1.2.0"
+    minimist "^1.2.2"
     strip-json-comments "~2.0.1"
 
 readable-stream@^2.0.6:


### PR DESCRIPTION
GitHub found 1 vulnerability using Minimist (indirect dependency)