### PR TITLE
dependencies(package-lock): Minimist 1.2.2 for security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -461,7 +461,7 @@
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
-            "minimist": "^1.2.0",
+            "minimist": "^1.2.2",
             "strip-json-comments": "~2.0.1"
           }
         },


### PR DESCRIPTION
GitHub found 1 vulnerability using Minimist (Indirect dependency)